### PR TITLE
Removed Unicode spaces that were interfering with copied commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ This is the full workshop that covers Kubernetes 101, Helm, virtual kubelet and 
 * Writing our own chart
 * Helm and CNAB
 
- Kubernetes advanced topics​
+ Kubernetes advanced topics
 
 * Virtual kubelet
 * Pod security context 
 * Introduction to istio
-* Advanced application routing with istio​
+* Advanced application routing with istio
 * Setting mTLS between application services with istio 
 
 This workshop takes about 6hrs to give as instructor lead workshop.  

--- a/advance-application-routing-with-istio/code.md
+++ b/advance-application-routing-with-istio/code.md
@@ -208,4 +208,4 @@ EOF
 ```
 
 ## Get your ingress ip
-`kubectl get svc istio-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[0].ip}"​`
+`kubectl get svc istio-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[0].ip}"`

--- a/deploying-kubernetes-on-azure/code.md
+++ b/deploying-kubernetes-on-azure/code.md
@@ -14,7 +14,7 @@ az aks create --resource-group k8s \
 ```
 
 ## If you dont have the kubectl binary installed
-`​az aks install-cli`
+`az aks install-cli`
 
 ## Get your cluster credentials
 `az aks get-credentials --resource-group k8s --name k8s`

--- a/mTLS-with-istio/code.md
+++ b/mTLS-with-istio/code.md
@@ -103,8 +103,8 @@ kubectl exec -n istio-app -it $POD_NAME -c istio-proxy /bin/bash
 
 ## Let's capture traffic with tcpdump
 ```
-IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)​
-sudo tcpdump -vvv -A -i eth0 '((dst port 9080) and (net $IP))'​
+IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+sudo tcpdump -vvv -A -i eth0 '((dst port 9080) and (net $IP))'
 ```
 
 ## From another terminal

--- a/virtual-node-with-virtual-kubelet/code.md
+++ b/virtual-node-with-virtual-kubelet/code.md
@@ -4,7 +4,7 @@
 
 `az aks install-connector --resource-group k8s --name k8s --os-type both`
 
-`kubectl get nodes​`
+`kubectl get nodes`
 
 
 ```


### PR DESCRIPTION
Fixes this problem:

```
$ az aks install-cli
az: command not found
```

(This because some commands in the presentation had a Unicode 0x200b character at the start or end of the line.)