### PR TITLE
https://github.com/virtual-kubelet/virtual-kubelet/issues/153

### DIFF
--- a/virtual-node-with-virtual-kubelet/code.md
+++ b/virtual-node-with-virtual-kubelet/code.md
@@ -2,6 +2,8 @@
 
 ## Deploying virtual Kubeket
 
+`az provider register -n Microsoft.ContainerInstance`
+
 `az aks install-connector --resource-group k8s --name k8s --os-type both`
 
 `kubectl get nodes`
@@ -20,6 +22,9 @@ spec:
     name: vk-webapp
     resources:
       requests:
+        memory: 1G
+        cpu: 1
+      limits:
         memory: 1G
         cpu: 1
     ports:


### PR DESCRIPTION
Added limits to resource request
[Schedule a pod in ACI example needs to sets resource limits in order to work](https://github.com/virtual-kubelet/virtual-kubelet/issues/153)

Also `Microsoft.ContainerInstance` is not enabled by default in some subscriptions. This is required for ACI.