### PR TITLE
Patched the Dockerfile to fix bash_completion

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,12 @@
+# Use bash-completion
+[[ -f /usr/share/bash-completion/bash_completion ]] && \
+    . /usr/share/bash-completion/bash_completion
+# Source kubectl
+[[ -f /usr/local/bin/kubectl ]] && \
+    source <(kubectl completion bash)
+# Source azure-cli
+[[ -f /usr/bin/az.completion.sh ]] && \
+    source /usr/bin/az.completion.sh
+# Change Prompt
+export PS1="\w \$ "
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add bash \
             openssl-dev \
             python-dev \
             make \
+            coreutils \
             ca-certificates && \
     curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.15.7/bin/linux/amd64/kubectl && \
     mv kubectl /usr/local/bin && \
@@ -37,4 +38,7 @@ ENV PATH="$PATH:/root/.porter"
 ENV PATH="$PATH:/root/.linkerd2/bin"   
 ENV PATH="$PATH:/root/.supergloo/bin"  
 
+ADD .bashrc /root/.bashrc
+
 WORKDIR /workshop
+


### PR DESCRIPTION
Thanks for running your kubernetes 101 training session yesterday.

I've made some amendments to your docker file to get bash completion working for `kubectl` and `az` double <tab>

I also replace `base64` with the one from coreutils so your scripts can work with the full `--decode` argument.

if you jump into the container using `bash` instead of `sh` it should work for you.

Good Luck with your session at ignite.

Gary